### PR TITLE
Guard streaming prompts against context growth

### DIFF
--- a/services/webinfer/README.md
+++ b/services/webinfer/README.md
@@ -110,7 +110,8 @@ Recommended image input format is the OpenAI format:
    - `</silence>`
    - `</response> one-sentence reply`
 8. Every full `CHUNK` frames, an intermediate summary is generated. Every `COMPRESS_EVERY_N_CHUNKS` intermediate summaries, they are compressed into long-term memory.
-9. The response is returned as standard chat completion JSON, with extra `streamingharness.memory/timing/raw_content` fields.
+9. Optional prompt-window limits apply only to main-model requests; the full session continues through chunk summaries and long-term memory. A failed main-model request is rolled back so its frames are not appended again on retry.
+10. The response is returned as standard chat completion JSON, with extra `streamingharness.memory/timing/raw_content` fields.
 
 ## Key Parameters
 
@@ -125,6 +126,8 @@ Recommended image input format is the OpenAI format:
 | `ADAPTER_PORT` | `8070` | Adapter listen port. |
 | `MAIN_BACKENDS` | See `scripts/start_adapter.sh` | Main-model backend JSON, routed by request `model`. |
 | `MAIN_MAX_TOKENS` | Script default `256` | Main-model output length. |
+| `MAIN_MAX_PROMPT_TURNS` | `0` | Maximum recent user turns sent to the main model. `0` keeps the full current chunk. |
+| `MAIN_MAX_PROMPT_IMAGES` | `0` | Maximum recent images sent to the main model. `0` keeps all current-chunk images. |
 | `MAIN_TEMPERATURE` | `0.8` | Main-model sampling temperature. |
 | `CHUNK` | Script default `100` | Number of frames per memory chunk. |
 | `COMPRESS_EVERY_N_CHUNKS` | `5` | Number of intermediate summaries to accumulate before compressing into long-term memory. |

--- a/services/webinfer/README.zh-CN.md
+++ b/services/webinfer/README.zh-CN.md
@@ -110,7 +110,8 @@ x-streaming-session: <sessionId>
    - `</silence>`
    - `</response> one-sentence reply`
 8. 每满 `CHUNK` 帧，会生成一条中间摘要。每累计 `COMPRESS_EVERY_N_CHUNKS` 条中间摘要，它们会被压缩为长期记忆。
-9. 响应以标准 chat completion JSON 返回，并带有额外的 `streamingharness.memory/timing/raw_content` 字段。
+9. 可选的提示窗口限制只作用于主模型请求；完整会话仍通过 chunk 摘要和长期记忆保留。主模型请求失败时会回滚本轮，避免重试后重复累计图像。
+10. 响应以标准 chat completion JSON 返回，并带有额外的 `streamingharness.memory/timing/raw_content` 字段。
 
 ## 关键参数
 
@@ -125,6 +126,8 @@ x-streaming-session: <sessionId>
 | `ADAPTER_PORT` | `8070` | 适配器监听端口。 |
 | `MAIN_BACKENDS` | 见 `scripts/start_adapter.sh` | 主模型后端 JSON，按请求中的 `model` 路由。 |
 | `MAIN_MAX_TOKENS` | 脚本默认 `256` | 主模型输出长度。 |
+| `MAIN_MAX_PROMPT_TURNS` | `0` | 发送给主模型的最近用户轮数上限；`0` 表示保留当前 chunk 的完整历史。 |
+| `MAIN_MAX_PROMPT_IMAGES` | `0` | 发送给主模型的最近图像数上限；`0` 表示保留当前 chunk 的全部图像。 |
 | `MAIN_TEMPERATURE` | `0.8` | 主模型采样温度。 |
 | `CHUNK` | 脚本默认 `100` | 每个记忆 chunk 的帧数。 |
 | `COMPRESS_EVERY_N_CHUNKS` | `5` | 压缩为长期记忆前累计的中间摘要数量。 |

--- a/services/webinfer/live_adapter.py
+++ b/services/webinfer/live_adapter.py
@@ -160,6 +160,126 @@ def reset_chunk_state() -> dict[str, Any]:
     }
 
 
+_APPEND_ONLY_CHUNK_FIELDS = (
+    "messages",
+    "response_records",
+    "image_paths",
+    "frame_time_ranges",
+    "summarizer_frame_cache",
+    "api_msg_cache",
+)
+
+
+def _snapshot_append_only_chunk_state(chunk: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "frame_count": chunk["frame_count"],
+        "turn_count": chunk["turn_count"],
+        "lengths": {
+            field: len(chunk[field])
+            for field in _APPEND_ONLY_CHUNK_FIELDS
+        },
+    }
+
+
+def _restore_append_only_chunk_state(
+    chunk: dict[str, Any],
+    snapshot: dict[str, Any],
+) -> None:
+    chunk["frame_count"] = snapshot["frame_count"]
+    chunk["turn_count"] = snapshot["turn_count"]
+    for field, length in snapshot["lengths"].items():
+        del chunk[field][length:]
+
+
+def _internal_image_count(messages: list[dict[str, Any]]) -> int:
+    count = 0
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        count += sum(
+            1
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "image"
+        )
+    return count
+
+
+def _limit_internal_messages(
+    messages: list[dict[str, Any]],
+    *,
+    max_turns: int = 0,
+    max_images: int = 0,
+) -> list[dict[str, Any]]:
+    """Return a recent prompt window without mutating the session history.
+
+    A turn starts with a user message and includes all following messages up to
+    the next user message. Limits less than or equal to zero are disabled.
+    When the newest retained turn alone exceeds ``max_images``, its oldest
+    images are removed while text and the most recent images are preserved.
+    """
+
+    max_turns = max(0, int(max_turns or 0))
+    max_images = max(0, int(max_images or 0))
+    if max_turns == 0 and max_images == 0:
+        return list(messages)
+
+    leading: list[dict[str, Any]] = []
+    turns: list[list[dict[str, Any]]] = []
+    for message in messages:
+        if message.get("role") == "user":
+            turns.append([message])
+        elif turns:
+            turns[-1].append(message)
+        else:
+            leading.append(message)
+
+    if max_turns > 0 and len(turns) > max_turns:
+        turns = turns[-max_turns:]
+
+    if max_images > 0:
+        total_images = _internal_image_count(
+            [message for turn in turns for message in turn]
+        )
+        while total_images > max_images and len(turns) > 1:
+            removed = turns.pop(0)
+            total_images -= _internal_image_count(removed)
+
+    limited = leading + [message for turn in turns for message in turn]
+    if max_images <= 0:
+        return limited
+
+    images_to_remove = max(0, _internal_image_count(limited) - max_images)
+    if images_to_remove == 0:
+        return limited
+
+    result: list[dict[str, Any]] = []
+    for message in limited:
+        content = message.get("content")
+        if images_to_remove == 0 or not isinstance(content, list):
+            result.append(message)
+            continue
+        new_content: list[Any] = []
+        changed = False
+        for item in content:
+            if (
+                images_to_remove > 0
+                and isinstance(item, dict)
+                and item.get("type") == "image"
+            ):
+                images_to_remove -= 1
+                changed = True
+                continue
+            new_content.append(item)
+        if changed:
+            new_message = dict(message)
+            new_message["content"] = new_content
+            result.append(new_message)
+        else:
+            result.append(message)
+    return result
+
+
 def _parse_start_second(time_range: Optional[str]) -> float:
     if not time_range:
         return -1.0
@@ -518,6 +638,8 @@ class AdapterConfig:
     frame_seconds: float = 1.0
     max_pixels: int = 262144
     main_max_tokens: int = 128
+    main_max_prompt_turns: int = 0
+    main_max_prompt_images: int = 0
     main_temperature: float = 0.8
     main_top_p: float = 0.9
     main_top_k: int = 40
@@ -1112,6 +1234,7 @@ class StreamingInferAdapter:
                 time_ranges.append(self._time_range_for_frame(state.frame_count + i))
         time_range = _format_turn_time_range(time_ranges)
 
+        session_frame_counter_snapshot = state.session_frame_counter
         image_paths = [self._resolve_frame_ref(ref, state) for ref in image_refs]
         LOGGER.info(
             "[%s] turn=%d frames=%d(+%d) chunk=%d time=%s prompt=%r",
@@ -1182,6 +1305,16 @@ class StreamingInferAdapter:
             state.chunk_index += 1
             state.query_in_current_chunk = bool(query_text)
 
+        turn_state_snapshot = {
+            "frame_count": state.frame_count,
+            "turn_count": state.turn_count,
+            "session_frame_counter": session_frame_counter_snapshot,
+            "current_chunk": _snapshot_append_only_chunk_state(state.current_chunk),
+            "async_summary_segment": _snapshot_append_only_chunk_state(
+                state.async_summary_segment
+            ),
+        }
+
         for tr, ip in zip(time_ranges, image_paths):
             state.frame_count += 1
             state.current_chunk["image_paths"].append(str(ip))
@@ -1243,47 +1376,68 @@ class StreamingInferAdapter:
             if self.config.save_model_inputs:
                 model_input_record = turn_model_input_record
         else:
-            t_prompt_build_start = time.perf_counter()
-            internal_messages, prefix_content = self._build_main_internal_messages(state)
-            api_messages = self._build_cached_api_messages(state, internal_messages)
-            generation_kwargs = self._main_generation_kwargs(payload)
-            http_messages = self._build_main_http_messages(api_messages, payload)
-            turn_model_input_record = build_model_input_record(
-                chunk_index=state.chunk_index,
-                messages=http_messages,
-                frame_count=state.current_chunk["frame_count"],
-                model=model_name,
-                generation_kwargs=generation_kwargs,
-                image_paths=state.current_chunk["image_paths"],
-                frame_time_ranges=state.current_chunk["frame_time_ranges"],
-                prefix_content=prefix_content,
-            )
-            if self.config.save_model_inputs:
-                model_input_record = turn_model_input_record
-            chunk_start_model_input_path = self._maybe_save_chunk_start_model_input(
-                state,
-                turn_count,
-                time_range,
-                turn_model_input_record,
-            )
-            t_prompt_build_end = time.perf_counter()
-            inference_start = time.time()
-            raw_text, usage = await self._call_main_model(
-                payload,
-                api_messages,
-                client=client,
-                model_name=model_name,
-                session_state=state,
-                generation_kwargs=generation_kwargs,
-                http_messages=http_messages,
-            )
-            inference_time = time.time() - inference_start
-            t_inference_end = time.perf_counter()
-            generated_text = (
-                normalize_model_output(raw_text)
-                if self.config.normalize_output
-                else (raw_text or "").strip()
-            )
+            try:
+                t_prompt_build_start = time.perf_counter()
+                internal_messages, prefix_content = self._build_main_internal_messages(state)
+                api_messages = self._build_cached_api_messages(state, internal_messages)
+                generation_kwargs = self._main_generation_kwargs(payload)
+                http_messages = self._build_main_http_messages(api_messages, payload)
+                turn_model_input_record = build_model_input_record(
+                    chunk_index=state.chunk_index,
+                    messages=http_messages,
+                    frame_count=state.current_chunk["frame_count"],
+                    model=model_name,
+                    generation_kwargs=generation_kwargs,
+                    image_paths=state.current_chunk["image_paths"],
+                    frame_time_ranges=state.current_chunk["frame_time_ranges"],
+                    prefix_content=prefix_content,
+                )
+                if self.config.save_model_inputs:
+                    model_input_record = turn_model_input_record
+                t_prompt_build_end = time.perf_counter()
+                inference_start = time.time()
+                raw_text, usage = await self._call_main_model(
+                    payload,
+                    api_messages,
+                    client=client,
+                    model_name=model_name,
+                    session_state=state,
+                    generation_kwargs=generation_kwargs,
+                    http_messages=http_messages,
+                )
+                inference_time = time.time() - inference_start
+                t_inference_end = time.perf_counter()
+                generated_text = (
+                    normalize_model_output(raw_text)
+                    if self.config.normalize_output
+                    else (raw_text or "").strip()
+                )
+                chunk_start_model_input_path = self._maybe_save_chunk_start_model_input(
+                    state,
+                    turn_count,
+                    time_range,
+                    turn_model_input_record,
+                )
+            except Exception:
+                state.frame_count = turn_state_snapshot["frame_count"]
+                state.turn_count = turn_state_snapshot["turn_count"]
+                state.session_frame_counter = turn_state_snapshot[
+                    "session_frame_counter"
+                ]
+                _restore_append_only_chunk_state(
+                    state.current_chunk,
+                    turn_state_snapshot["current_chunk"],
+                )
+                _restore_append_only_chunk_state(
+                    state.async_summary_segment,
+                    turn_state_snapshot["async_summary_segment"],
+                )
+                LOGGER.warning(
+                    "[%s] rolled back turn=%d after main-model failure",
+                    state.session_id,
+                    turn_count,
+                )
+                raise
 
         self._execute_pending_qa_archive(state)
 
@@ -1544,7 +1698,11 @@ class StreamingInferAdapter:
         prefix_content = "\n\n".join(
             part for part in (static_content, dynamic_content) if part
         )
-        all_messages = list(state.current_chunk["messages"])
+        all_messages = _limit_internal_messages(
+            state.current_chunk["messages"],
+            max_turns=self.config.main_max_prompt_turns,
+            max_images=self.config.main_max_prompt_images,
+        )
 
         if prefix_content:
             for idx, message in enumerate(all_messages):
@@ -1574,6 +1732,15 @@ class StreamingInferAdapter:
         state: SessionState,
         internal_messages: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
+        if (
+            self.config.main_max_prompt_turns > 0
+            or self.config.main_max_prompt_images > 0
+        ):
+            return [
+                _internal_message_to_openai(message)
+                for message in internal_messages
+            ]
+
         cache = state.current_chunk["api_msg_cache"]
         chunk_msgs = state.current_chunk["messages"]
         # Incrementally convert new chunk messages and append to cache.
@@ -2349,6 +2516,18 @@ def parse_args() -> AdapterConfig:
     parser.add_argument("--max-pixels", type=int, default=_env_int("MAX_PIXELS", 262144))
     parser.add_argument("--main-max-tokens", type=int, default=_env_int("MAIN_MAX_TOKENS", 128))
     parser.add_argument(
+        "--main-max-prompt-turns",
+        type=int,
+        default=_env_int("MAIN_MAX_PROMPT_TURNS", 0),
+        help="Keep at most this many recent user turns in main-model prompts; 0 disables the limit.",
+    )
+    parser.add_argument(
+        "--main-max-prompt-images",
+        type=int,
+        default=_env_int("MAIN_MAX_PROMPT_IMAGES", 0),
+        help="Keep at most this many recent images in main-model prompts; 0 disables the limit.",
+    )
+    parser.add_argument(
         "--main-temperature",
         type=float,
         default=_env_float("MAIN_TEMPERATURE", 0.8),
@@ -2674,6 +2853,8 @@ def parse_args() -> AdapterConfig:
         frame_seconds=args.frame_seconds,
         max_pixels=args.max_pixels,
         main_max_tokens=args.main_max_tokens,
+        main_max_prompt_turns=max(0, args.main_max_prompt_turns),
+        main_max_prompt_images=max(0, args.main_max_prompt_images),
         main_temperature=args.main_temperature,
         main_top_p=args.main_top_p,
         main_top_k=args.main_top_k,

--- a/services/webinfer/scripts/start_adapter.sh
+++ b/services/webinfer/scripts/start_adapter.sh
@@ -49,6 +49,8 @@ ASYNC_SUMMARY_LEAD_FRAMES="${ASYNC_SUMMARY_LEAD_FRAMES:-10}"
 
 # ==================== 主 8B 模型采样参数 ====================
 MAIN_MAX_TOKENS="${MAIN_MAX_TOKENS:-256}"
+MAIN_MAX_PROMPT_TURNS="${MAIN_MAX_PROMPT_TURNS:-0}"
+MAIN_MAX_PROMPT_IMAGES="${MAIN_MAX_PROMPT_IMAGES:-0}"
 MAIN_TEMPERATURE="${MAIN_TEMPERATURE:-0.8}"
 MAIN_TOP_P="${MAIN_TOP_P:-0.9}"
 MAIN_TOP_K="${MAIN_TOP_K:-40}"
@@ -94,6 +96,7 @@ echo "  Frame save:    ${FRAME_SAVE_DIR}"
 echo "  Chunk:         ${CHUNK}"
 echo "  Compress N:    ${COMPRESS_EVERY_N_CHUNKS}"
 echo "  Async lead:    ${ASYNC_SUMMARY_LEAD_FRAMES}"
+echo "  Prompt window: turns=${MAIN_MAX_PROMPT_TURNS:-unlimited}, images=${MAIN_MAX_PROMPT_IMAGES:-unlimited} (0=unlimited)"
 echo "  Main sampling: max_tokens=${MAIN_MAX_TOKENS}, temp=${MAIN_TEMPERATURE}, top_p=${MAIN_TOP_P}, top_k=${MAIN_TOP_K}, rep_penalty=${MAIN_REPETITION_PENALTY}"
 if [[ -n "${ADAPTER_LOG_FILE}" ]]; then
     echo "  Log:           ${ADAPTER_LOG_FILE}"
@@ -118,6 +121,8 @@ echo "============================================================"
   --summarizer-key-frames "${SUMMARIZER_KEY_FRAMES}" \
   --summarizer-phase-seconds "${SUMMARIZER_PHASE_SECONDS}" \
   --main-max-tokens "${MAIN_MAX_TOKENS}" \
+  --main-max-prompt-turns "${MAIN_MAX_PROMPT_TURNS}" \
+  --main-max-prompt-images "${MAIN_MAX_PROMPT_IMAGES}" \
   --main-temperature "${MAIN_TEMPERATURE}" \
   --main-top-p "${MAIN_TOP_P}" \
   --main-top-k "${MAIN_TOP_K}" \

--- a/services/webinfer/tests/test_live_adapter.py
+++ b/services/webinfer/tests/test_live_adapter.py
@@ -1,0 +1,141 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+
+WEBINFER_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(WEBINFER_DIR))
+
+from live_adapter import (  # noqa: E402
+    AdapterConfig,
+    StreamingInferAdapter,
+    _internal_image_count,
+    _limit_internal_messages,
+)
+
+
+def _turn(index: int, image_count: int = 1) -> list[dict]:
+    content = [{"type": "text", "text": f"turn {index}"}]
+    content.extend(
+        {"type": "image", "image": f"image-{index}-{image_index}.png"}
+        for image_index in range(image_count)
+    )
+    return [
+        {"role": "user", "content": content},
+        {"role": "assistant", "content": f"answer {index}"},
+    ]
+
+
+class PromptWindowTests(unittest.TestCase):
+    def test_limits_recent_complete_turns(self):
+        messages = _turn(1) + _turn(2) + _turn(3)
+
+        limited = _limit_internal_messages(messages, max_turns=2)
+
+        self.assertEqual(
+            [
+                message["content"][0]["text"]
+                for message in limited
+                if message["role"] == "user"
+            ],
+            ["turn 2", "turn 3"],
+        )
+        self.assertEqual(
+            [
+                message["content"]
+                for message in limited
+                if message["role"] == "assistant"
+            ],
+            ["answer 2", "answer 3"],
+        )
+
+    def test_limits_images_and_preserves_text_and_newest_images(self):
+        messages = _turn(1, image_count=2) + _turn(2, image_count=3)
+
+        limited = _limit_internal_messages(messages, max_images=2)
+
+        self.assertEqual(_internal_image_count(limited), 2)
+        self.assertEqual(
+            len([message for message in limited if message["role"] == "user"]),
+            1,
+        )
+        user_content = limited[0]["content"]
+        self.assertEqual(user_content[0], {"type": "text", "text": "turn 2"})
+        self.assertEqual(
+            [item["image"] for item in user_content if item["type"] == "image"],
+            ["image-2-1.png", "image-2-2.png"],
+        )
+
+    def test_caps_a_long_stream_below_backend_image_limit(self):
+        messages = [message for index in range(1, 41) for message in _turn(index)]
+
+        limited = _limit_internal_messages(messages, max_images=32)
+
+        self.assertEqual(_internal_image_count(limited), 32)
+        user_messages = [
+            message for message in limited if message["role"] == "user"
+        ]
+        self.assertEqual(user_messages[0]["content"][0]["text"], "turn 9")
+        self.assertEqual(user_messages[-1]["content"][0]["text"], "turn 40")
+
+    def test_disabled_limits_do_not_mutate_messages(self):
+        messages = _turn(1, image_count=2)
+
+        limited = _limit_internal_messages(messages)
+
+        self.assertEqual(limited, messages)
+        self.assertIsNot(limited, messages)
+        self.assertEqual(_internal_image_count(messages), 2)
+
+
+class FailedTurnRollbackTests(unittest.IsolatedAsyncioTestCase):
+    async def test_main_model_failure_rolls_back_appended_turn(self):
+        with tempfile.TemporaryDirectory() as frame_dir:
+            adapter = StreamingInferAdapter(
+                AdapterConfig(
+                    enable_summarizer=False,
+                    force_silence_before_query=False,
+                    frame_save_dir=frame_dir,
+                    per_session_dirs=False,
+                    save_model_inputs=False,
+                )
+            )
+            self.addAsyncCleanup(adapter.main_client.close)
+            adapter._call_main_model = AsyncMock(side_effect=RuntimeError("backend failed"))
+            state = adapter.get_session("rollback-test")
+            request = SimpleNamespace(headers={})
+            payload = {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "What is happening?"},
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+                                },
+                            },
+                        ],
+                    }
+                ]
+            }
+
+            with self.assertRaisesRegex(RuntimeError, "backend failed"):
+                await adapter._handle_chat_payload(state, payload, request)
+
+            self.assertEqual(state.frame_count, 0)
+            self.assertEqual(state.turn_count, 0)
+            self.assertEqual(state.session_frame_counter, 0)
+            self.assertEqual(state.current_chunk["frame_count"], 0)
+            self.assertEqual(state.current_chunk["turn_count"], 0)
+            self.assertEqual(state.current_chunk["messages"], [])
+            self.assertEqual(state.current_chunk["image_paths"], [])
+            self.assertEqual(state.async_summary_segment["messages"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add opt-in recent-turn and recent-image windows for main-model prompts
- preserve full chunk/session state for summarization and long-term memory
- roll back the current turn when prompt construction or the main-model request fails
- expose the new settings through CLI arguments, environment variables, and `start_adapter.sh`
- document the behavior in English and Chinese and add regression tests

Both limits default to `0` (unlimited), so existing deployments keep their current prompt behavior.

Fixes #35.

## Validation

- `python -m unittest discover -s services/webinfer/tests -v` (5 tests passed)
- `python -m py_compile services/webinfer/live_adapter.py services/webinfer/tests/test_live_adapter.py`
- `bash -n services/webinfer/scripts/start_adapter.sh`
- `git diff --check`
- local end-to-end adapter run with 9 sequential image turns against an OpenAI-compatible vLLM backend; the final queried turn completed successfully
- forced backend failure followed by a retry stayed at the same turn/frame count, confirming rollback
